### PR TITLE
scope clojurescript.test dependency to test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/clojurescript "0.0-2277"]
                  [com.cemerick/clojurescript.test "0.3.1"]]
   :plugins [[lein-cljsbuild "1.0.3"]
-            [com.cemerick/clojurescript.test "0.3.1"]
+            [com.cemerick/clojurescript.test "0.3.1" :scope "test"]
             [com.cemerick/austin "0.1.4"]]
   :cljsbuild {:builds [{:source-paths ["src" "test"]
                         :compiler {:output-to "target/cljs/whitespace.js"


### PR DESCRIPTION
1. I don't think we need to distribute the test lib we use along with
   our binary/cljs source
2. If we leave this in the default scope, it produces dependency
   conflicts with other libs that depend on older versions of
   clojurescript.test. These conflicts are typically visiable via warning
   messages after running `lein deps :tree`
