### PR TITLE
Adds support for user defined separator and newline for read-csv

### DIFF
--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -43,9 +43,21 @@
                   quote?)
       (throw (js/Error. newline-error-message)))))
 
+(defn escape-regex-chars
+  "To make it easier, escapes everything that's not alphanumeric or whitespace,
+   which should be safe: http://eloquentjavascript.net/09_regexp.html"
+  [string]
+  (str/replace string #"[^\w\s]" "\\$&"))
+
+(defn str->pattern [string]
+  (-> string
+      escape-regex-chars
+      re-pattern))
+
 (defn read-csv
   "Reads data from String in CSV-format."
   {:arglists '([data] [data & options]) :added "0.3.0"}
   [data & options]
-  (map #(str/split % #",")
-       (str/split data #"\n")))
+  (let [{:keys [separator] :or {separator ","}} options]
+    (->> (str/split data #"\n")
+         (map #(str/split % (str->pattern separator))))))

--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -43,21 +43,12 @@
                   quote?)
       (throw (js/Error. newline-error-message)))))
 
-(defn escape-regex-chars
-  "To make it easier, escapes everything that's not alphanumeric or whitespace,
-   which should be safe: http://eloquentjavascript.net/09_regexp.html"
-  [string]
-  (str/replace string #"[^\w\s]" "\\$&"))
-
-(defn str->pattern [string]
-  (-> string
-      escape-regex-chars
-      re-pattern))
-
 (defn read-csv
   "Reads data from String in CSV-format."
   {:arglists '([data] [data & options]) :added "0.3.0"}
   [data & options]
-  (let [{:keys [separator] :or {separator ","}} options]
-    (->> (str/split data #"\n")
-         (map #(str/split % (str->pattern separator))))))
+  (let [{:keys [separator newline] :or {separator "," newline :lf}} options]
+    (if-let [newline-char (get newlines newline)]
+      (->> (str/split data newline-char)
+           (map #(str/split % separator)))
+      (throw (js/Error. newline-error-message)))))

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -31,7 +31,13 @@
       (is (= data (csv/read-csv "1,2,3\n4,5,6"))))
 
     (testing "user defined separator '|'"
-      (is (= data (csv/read-csv "1|2|3\n4|5|6" :separator "|"))))))
+      (is (= data (csv/read-csv "1|2|3\n4|5|6" :separator "|"))))
+
+    (testing "user defined newline ':cr+lf'"
+      (is (= data (csv/read-csv "1,2,3\r\n4,5,6" :newline :cr+lf))))
+
+    (testing "user defined separator '|' and newline ':cr+lf'"
+      (is (= data (csv/read-csv "1|2|3\r\n4|5|6" :separator "|" :newline :cr+lf))))))
 
 (defn ^:export run []
   (run-tests))

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -28,7 +28,10 @@
 (deftest read-csv-test
   (let [data [["1" "2" "3"] ["4" "5" "6"]]]
     (testing "default separator ','"
-      (is (= data (csv/read-csv "1,2,3\n4,5,6"))))))
+      (is (= data (csv/read-csv "1,2,3\n4,5,6"))))
+
+    (testing "user defined separator '|'"
+      (is (= data (csv/read-csv "1|2|3\n4|5|6" :separator "|"))))))
 
 (defn ^:export run []
   (run-tests))


### PR DESCRIPTION
I am writing a small script that deals with CSVs and that required a separator other than `,`. When trying to read the CSV, I realized that:

1. The version published in Clojars of this library does not include the `read-csv` function (as pointed out in https://github.com/testdouble/clojurescript.csv/issues/4)
2. The version of `read-csv` in `master` does not support user defined separator and newline

This PR adds support for it :)

It would be awesome if we can merge and publish this!