### PR TITLE
Add RFC 4180 compliance

### DIFF
--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -1,8 +1,11 @@
 (ns testdouble.cljs.csv
   (:require [clojure.string :as str]))
 
+(defn- escape-quotes [s]
+  (str/replace s "\"" "\"\""))
+
 (defn- wrap-in-quotes [s]
-  (str "\"" s "\""))
+  (str "\"" (escape-quotes s) "\""))
 
 (defn- seperate [data separator quote?]
   (str/join separator

--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -12,6 +12,9 @@
 (defn- write-data [data separator newline quote?]
   (str/join newline (map #(seperate % separator quote?) data)))
 
+(defn- conj-in [coll index x]
+  (assoc coll index (conj (nth coll index) x)))
+
 (def ^:private newlines
   {:lf "\n" :cr+lf "\r\n"})
 
@@ -49,6 +52,101 @@
   [data & options]
   (let [{:keys [separator newline] :or {separator "," newline :lf}} options]
     (if-let [newline-char (get newlines newline)]
-      (->> (str/split data newline-char)
-           (map #(str/split % separator)))
+      (let [data-length (count data)]
+        (loop [index 0
+               state :in-field
+               in-quoted-field false
+               field-buffer nil
+               rows nil]
+          (let [last-row-index (- (count rows) 1)]
+            (if (< index data-length)
+              (let [char (nth data index)
+                    next-char (if (< index (- data-length 1))
+                                (nth data (+ index 1))
+                                nil)
+                    str-char (str char)]
+                (case state
+                  :in-field
+                  (cond
+                    (= str-char "\"")
+                    (if in-quoted-field
+                      (if (= (str next-char) "\"")
+                        (recur (+ index 2)
+                               :in-field
+                               true
+                               (str field-buffer char)
+                               rows)
+                        (recur (+ index 1) :in-field false field-buffer rows))
+                      (recur (+ index 1) :in-field true field-buffer rows))
+
+                    (= str-char separator)
+                    (if in-quoted-field
+                      (recur (+ index 1)
+                             :in-field
+                             in-quoted-field
+                             (str field-buffer char)
+                             rows)
+                      (recur (+ index 1)
+                             :end-field
+                             in-quoted-field
+                             ""
+                             (conj-in rows last-row-index field-buffer)))
+
+                    (= str-char "\r")
+                    (if (and (= newline :cr+lf) (not in-quoted-field))
+                      (recur (+ index 1)
+                             :in-field
+                             in-quoted-field
+                             field-buffer
+                             rows)
+                      (recur (+ index 1)
+                             :in-field
+                             in-quoted-field
+                             (str field-buffer char)
+                             rows))
+
+                    (= str-char "\n")
+                    (if in-quoted-field
+                      (recur (+ index 1)
+                             :in-field
+                             in-quoted-field
+                             (str field-buffer char)
+                             rows)
+                      (recur (+ index 1)
+                             :end-line
+                             in-quoted-field
+                             ""
+                             (conj-in rows last-row-index field-buffer)))
+
+                    :else
+                    (recur (+ index 1)
+                           :in-field
+                           in-quoted-field
+                           (str field-buffer char)
+                           (if (> (count rows) 0)
+                             rows
+                             (conj (or rows []) []))))
+
+                  :end-field
+                  (case str-char
+                    "\""
+                    (recur (+ index 1) :in-field true field-buffer rows)
+
+                    (recur (+ index 1) :in-field in-quoted-field str-char rows))
+
+                  :end-line
+                  (case str-char
+                    "\""
+                    (recur (+ index 1)
+                           :in-field
+                           true
+                           field-buffer
+                           (conj (or rows []) []))
+
+                    (recur (+ index 1)
+                           :in-field
+                           in-quoted-field
+                           (str field-buffer char)
+                           (conj (or rows []) [])))))
+              (conj-in rows last-row-index field-buffer)))))
       (throw (js/Error. newline-error-message)))))

--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -60,7 +60,7 @@
                state :in-field
                in-quoted-field false
                field-buffer nil
-               rows nil]
+               rows []]
           (let [last-row-index (- (count rows) 1)]
             (if (< index data-length)
               (let [char (nth data index)
@@ -80,7 +80,13 @@
                                (str field-buffer char)
                                rows)
                         (recur (+ index 1) :in-field false field-buffer rows))
-                      (recur (+ index 1) :in-field true field-buffer rows))
+                      (recur (+ index 1)
+                             :in-field
+                             true
+                             field-buffer
+                             (if (> (count rows) 0)
+                               rows
+                               (conj rows []))))
 
                     (= str-char separator)
                     (if in-quoted-field
@@ -128,7 +134,7 @@
                            (str field-buffer char)
                            (if (> (count rows) 0)
                              rows
-                             (conj (or rows []) []))))
+                             (conj rows []))))
 
                   :end-field
                   (case str-char

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -26,6 +26,12 @@
       (is (= "\"a\nb\",\"c\rd\"\n\"e,f\",\"g\"\"h\""
              (csv/write-csv [["a\nb" "c\rd"] ["e,f" "g\"h"]] :quote? true))))
 
+    (testing "fields with spaces"
+      (is (= "a b,c d\ne f,g h"
+             (csv/write-csv [["a b" "c d"] ["e f" "g h"]])))
+      (is (= "\"a b\",\"c d\"\n\"e f\",\"g h\""
+             (csv/write-csv [["a b" "c d"] ["e f" "g h"]] :quote? true))))
+
     (testing "error when newline is not one of :lf OR :cr+lf"
       (is (thrown-with-msg? js/Error #":newline" (csv/write-csv data :newline "foo"))))))
 
@@ -49,7 +55,11 @@
 
     (testing "quoted fields containing only quotes"
       (is (= [["\"" "\"\""] ["\"\"\"" "\"\"\"\""]]
-             (csv/read-csv "\"\"\"\",\"\"\"\"\"\"\n\"\"\"\"\"\"\"\",\"\"\"\"\"\"\"\"\"\""))))))
+             (csv/read-csv "\"\"\"\",\"\"\"\"\"\"\n\"\"\"\"\"\"\"\",\"\"\"\"\"\"\"\"\"\""))))
+
+    (testing "fields with spaces"
+      (is (= [["a b" "c d"] ["e f" "g h"]]
+             (csv/read-csv "\"a b\",c d\ne f,\"g h\""))))))
 
 (defn ^:export run []
   (run-tests))

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -22,6 +22,10 @@
     (testing "quote each field"
       (is (= "\"1,000\",\"2\",\"3\"\n\"4\",\"5,000\",\"6\"" (csv/write-csv [["1,000" "2" "3"] ["4" "5,000" "6"]] :quote? true))))
 
+    (testing "valid characters in quoted fields"
+      (is (= "\"a\nb\",\"c\rd\"\n\"e,f\",\"g\"\"h\""
+             (csv/write-csv [["a\nb" "c\rd"] ["e,f" "g\"h"]] :quote? true))))
+
     (testing "error when newline is not one of :lf OR :cr+lf"
       (is (thrown-with-msg? js/Error #":newline" (csv/write-csv data :newline "foo"))))))
 
@@ -37,7 +41,11 @@
       (is (= data (csv/read-csv "1,2,3\r\n4,5,6" :newline :cr+lf))))
 
     (testing "user defined separator '|' and newline ':cr+lf'"
-      (is (= data (csv/read-csv "1|2|3\r\n4|5|6" :separator "|" :newline :cr+lf))))))
+      (is (= data (csv/read-csv "1|2|3\r\n4|5|6" :separator "|" :newline :cr+lf))))
+
+    (testing "valid characters in quoted fields"
+      (is (= [["a\nb" "c\rd"] ["e,f" "g\"h"]]
+             (csv/read-csv "\"a\nb\",\"c\rd\"\n\"e,f\",\"g\"\"h\""))))))
 
 (defn ^:export run []
   (run-tests))

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -45,7 +45,11 @@
 
     (testing "valid characters in quoted fields"
       (is (= [["a\nb" "c\rd"] ["e,f" "g\"h"]]
-             (csv/read-csv "\"a\nb\",\"c\rd\"\n\"e,f\",\"g\"\"h\""))))))
+             (csv/read-csv "\"a\nb\",\"c\rd\"\n\"e,f\",\"g\"\"h\""))))
+
+    (testing "quoted fields containing only quotes"
+      (is (= [["\"" "\"\""] ["\"\"\"" "\"\"\"\""]]
+             (csv/read-csv "\"\"\"\",\"\"\"\"\"\"\n\"\"\"\"\"\"\"\",\"\"\"\"\"\"\"\"\"\""))))))
 
 (defn ^:export run []
   (run-tests))


### PR DESCRIPTION
Fixes https://github.com/testdouble/clojurescript.csv/issues/8, which noted that `read-csv` was broken for quoted fields.

As I understand it, [RFC 4180](https://www.ietf.org/rfc/rfc4180.txt) is the closest thing to a standard for CSV files. This PR does two things to add RFC 4180 compliance:
* Make `write-csv` properly escape double quotes in fields (when quoted output is requested)
* Rewrite `read-csv` entirely

The change to `write-csv` was trivial. However, RFC 4180 compliance for writing fields is only possible when using `:quote? true`. Even though using `write-csv` without quoted fields will not produce a RFC 4180-compliant CSV, I opted to not change the signature or options of `write-csv`.

Making `read-csv` RFC 4180-compliant required a complete rewrite of the function, along with complicated parsing. Specifically, parsing quoted fields requires much of the complexity. Even worse, RFC 4180 specifies that fields with double quotes must escape the double quote with another double quote (e.g., `"this is a ""quoted"" word"` decodes to `this is a "quoted" word`), which requires some extra state-keeping and character-skipping.

**I am under no illusions that `read-csv` represents good or pretty Clojure(Script).** It is ugly partly because CSV parsing is ugly. But I'm also no Clojure/CSV expert, so there's almost certainly a better way to express this functionality. I would welcome any assistance refactoring (or a wholesale rewrite of) the function.