### PR TITLE
Correctly read blank fields at beginning of row

### DIFF
--- a/src/testdouble/cljs/csv.cljs
+++ b/src/testdouble/cljs/csv.cljs
@@ -154,13 +154,20 @@
                     (recur (inc index) :in-field in-quoted-field str-char rows))
 
                   :end-line
-                  (case str-char
+                  (condp = str-char
                     "\""
                     (recur (inc index)
                            :in-field
                            true
                            field-buffer
                            (conj (or rows []) []))
+
+                    separator
+                    (recur (inc index)
+                           :end-field
+                           false
+                           ""
+                           (conj (or rows []) [""]))
 
                     (recur (inc index)
                            :in-field

--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -80,6 +80,12 @@
       (is (= [["a" "b" "c" "d"] ["1" "" "" "d"]]
              (csv/read-csv "a,b,c,d\n1,\"\",,d"))))
 
+    (testing "blank fields at beginning of row"
+      (is (= [["a" "b"]
+              ["" "1"]
+              ["" ""]]
+             (csv/read-csv "a,b\n,1\n,"))))
+
     (testing "blank fields at end of row"
       (is (= [["a" "b" "c"]
               ["1" "1" "1"]


### PR DESCRIPTION
The example in the test was parsing as:
```clojure
[["a" "b"]
 [",1"]
 [","]]
```
Now the test passes.

Note that there is a forthcoming PR that fixes this bug and several others. It makes `read-csv` smaller and clearer, and so I would prefer that it be merged. However, it is a bigger change, so if you feel it is too big, I'm submitting this smaller PR in hopes of getting this one bug fixed.