### PR TITLE
Correctly read lone newline in CRLF data

### DIFF
--- a/test/testdouble/cljs/csv_test.cljs
+++ b/test/testdouble/cljs/csv_test.cljs
@@ -67,6 +67,9 @@
     (testing "lone carriage return within ':cr-lf' newlines"
       (is (= [["1" "\r2" "3"] ["4" "5" "6"]] (csv/read-csv "1,\r2,3\r\n4,5,6" :newline :cr+lf))))
 
+    (testing "lone newline within ':cr-lf' newlines"
+      (is (= [["1" "\n2" "3"] ["4" "5" "6"]] (csv/read-csv "1,\n2,3\r\n4,5,6" :newline :cr+lf))))
+
     (testing "empty data"
       (is (= [[""]]
              (csv/read-csv ""))))


### PR DESCRIPTION
Before this change, newlines were always processed as end-of-line indicators, even in CRLF data.

This also adds a few comments to clarify the handling of quoted fields. Though these notes are unrelated to the change, I am hoping to sneak them in with a single PR.